### PR TITLE
Changes to travis build and update of deprecated functions 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,43 @@
-language: c
-sudo: false
+language: python
 
-os:
-    - osx
-    - linux
-env:
-    # Earliest supported versions
-    - CONDA_PY=2.7 PANDAS=0.18.1 PYSAM=0.10.0
-    - CONDA_PY=3.5 PANDAS=0.18.1 PYSAM=0.10.0
-    # The latest versions, whatever they are
-    - CONDA_PY=3.6 PANDAS='*' PYSAM='*'
+matrix:
+    include:
+        - os: linux
+          name: "Python 3.6 on Linux"
+          python: 3.6
+          env: CONDA_PY=3.6 PANDAS='*' PYSAM='*'
+
+        - os: linux
+          name: "Python 3.7 on Linux"
+          python: 3.7
+          env: CONDA_PY=3.7 PANDAS='*' PYSAM='*'
+
+        - os: osx
+          name: "Python 3.6 on MacOSX"
+          language: generic
+          env: CONDA_PY=3.6 PANDAS='*' PYSAM='*'
+
+        - os: osx
+          name: "Python 3.7 on MacOSX"
+          language: generic
+          env: CONDA_PY=3.7 PANDAS='*' PYSAM='*'
 
 install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; fi
-    - source devtools/travis-ci/install_miniconda.sh
+    - if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install md5sha1sum; fi
+    - source devtools/travis-ci/install_miniconda.sh;
 
 before_script:
     - conda create -yq --name testenv python=$CONDA_PY
     - source activate testenv
     - if [[ "$CONDA_PY" == "2.7" ]]; then conda install -yq futures>=3.0; fi
-    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then conda install -yq -c bioconda atlas; fi
-    # Install the versions desired for testing
-    - conda install -yq -c bioconda
-        cython
-        future
-        matplotlib
-        numpy
-        pyfaidx
-        pysam
-        reportlab
-        scipy
-        pandas==$PANDAS
-        pysam==$PYSAM
-    # R linking is broken on OS X - try recompilation instead of conda there
-    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
+    - if [ $TRAVIS_OS_NAME != 'osx' ]; then
         conda install -yq -c bioconda bioconductor-dnacopy r-cghflasso;
-      fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      else
         conda install -yq -c bioconda r-base;
-        Rscript -e "source('http://bioconductor.org/biocLite.R'); biocLite(c('DNAcopy', 'cghFLasso'))";
+        Rscript -e "chooseCRANmirror(ind = 1); install.packages('BiocManager'); BiocManager::install(c('DNAcopy', 'cghFLasso'))";
       fi
+    # Install the versions desired for testing
+    - conda install -yq -c bioconda cython future matplotlib numpy pyfaidx reportlab scipy pandas=$PANDAS pysam=$PYSAM
     # hmmlearn 0.2 isn't packaged for conda yet
     - pip install -q scikit-learn hmmlearn
     # Install CNVkit in-place from source
@@ -54,7 +52,7 @@ script:
     - coverage run -a test_cnvlib.py
     #- coverage run -a test_r.py
     # OS X can't install cghFLasso package?
-    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then coverage run -a test_r.py; fi
+    - if [ $TRAVIS_OS_NAME != 'osx' ]; then coverage run -a test_r.py; fi
 
 after_success:
     - coverage report

--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -211,7 +211,7 @@ def bedcov(bed_fname, bam_fname, min_mapq):
         raise ValueError("BED file %r chromosome names don't match any in "
                          "BAM file %r" % (bed_fname, bam_fname))
     columns = detect_bedcov_columns(raw)
-    table = pd.read_table(StringIO(raw), names=columns, usecols=columns)
+    table = pd.read_csv(StringIO(raw),  sep='\t', names=columns, usecols=columns)
     return table
 
 

--- a/cnvlib/import_rna.py
+++ b/cnvlib/import_rna.py
@@ -52,7 +52,8 @@ def aggregate_gene_counts(filenames):
     prev_row_count = None
     sample_cols = {}
     for fname in filenames:
-        d = (pd.read_table(fname,
+        d = (pd.read_csv(fname,
+                           sep='\t', 
                            header=None,
                            comment="_",
                            names=["gene_id", "expected_count"],
@@ -89,10 +90,11 @@ def aggregate_rsem(fnames):
     length_cols = []
     length_colname = 'length'  # or: 'effective_length'
     for fname in fnames:
-        # NB: read_table(index_col=_) works independently of combine=, dtype=
+        # NB: read_csv(index_col=_) works independently of combine=, dtype=
         #   so index column needs to be processed separately
         #   https://github.com/pandas-dev/pandas/issues/9435
-        d = pd.read_table(fname,
+        d = pd.read_csv(fname,
+                          sep='\t', 
                           usecols=['gene_id', length_colname, 'expected_count'],
                           #  index_col='gene_id',
                           converters={'gene_id': rna.before('.')}

--- a/cnvlib/reference.py
+++ b/cnvlib/reference.py
@@ -31,9 +31,9 @@ def do_reference(target_fnames, antitarget_fnames=None, fa_fname=None,
         # empty files, in which case no inference can be done. Since targets are
         # guaranteed to exist, infer from those first, then replace those
         # values where antitargets are suitable.
-        sexes = infer_sexes(target_fnames, male_reference)
+        sexes = infer_sexes(target_fnames, False)
         if antitarget_fnames:
-            a_sexes = infer_sexes(antitarget_fnames, male_reference)
+            a_sexes = infer_sexes(antitarget_fnames, False)
             for sid, a_is_xx in a_sexes.items():
                 t_is_xx = sexes.get(sid)
                 if t_is_xx is None:

--- a/cnvlib/rna.py
+++ b/cnvlib/rna.py
@@ -66,7 +66,7 @@ def load_gene_info(gene_resource, corr_fname, default_r=.1):
     # "Transcript support level (TSL)"
     info_col_names = ['gene_id', 'gc', 'chromosome', 'start', 'end',
                       'gene', 'entrez_id', 'tx_length', 'tx_support']
-    gene_info = (pd.read_table(gene_resource, names=info_col_names, header=1,
+    gene_info = (pd.read_csv(gene_resource, sep='\t', names=info_col_names, header=1,
                                converters={'gene_id': before('.'),
                                            'tx_support': tsl2int,
                                            'gc': lambda x: float(x)/100})
@@ -117,7 +117,7 @@ def load_gene_info(gene_resource, corr_fname, default_r=.1):
 
 def load_cnv_expression_corr(fname):
     shared_key = 'Entrez_Gene_Id'
-    table = (pd.read_table(fname, dtype={shared_key: int}, na_filter=False)
+    table = (pd.read_csv(fname, sep='\t', dtype={shared_key: int}, na_filter=False)
              .set_index(shared_key))
     logging.info("Loaded %s with shape: %s", fname, table.shape)
     return table

--- a/cnvlib/samutil.py
+++ b/cnvlib/samutil.py
@@ -20,7 +20,7 @@ def idxstats(bam_fname, drop_unmapped=False):
     chromosome. Contigs with no mapped reads are skipped.
     """
     handle = StringIO(pysam.idxstats(bam_fname, split_lines=False))
-    table = pd.read_table(handle, header=None,
+    table = pd.read_csv(handle, sep='\t', header=None,
                           names=['chromosome', 'length', 'mapped', 'unmapped'])
     if drop_unmapped:
         table = table[table.mapped != 0].drop('unmapped', axis=1)

--- a/scripts/cnv_expression_correlate.py
+++ b/scripts/cnv_expression_correlate.py
@@ -68,7 +68,7 @@ def load_tcga_table(fname, shared_key):
     Entrez_Gene_Id), only the sortest and then alphabetically first HUGO name is
     kept, ensuring Entrez_Gene_Id values are unique.
     """
-    table = pd.read_table(fname, dtype={shared_key: str}, na_filter=False)
+    table = pd.read_csv(fname, sep='\t', dtype={shared_key: str}, na_filter=False)
     table = table[table[shared_key] != ''].astype({shared_key: int})
     before_pipe = before('|')
     sort_order = (table['Hugo_Symbol']

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ setup_args = {}
 install_requires=[
         'biopython >= 1.62',
         'future >= 0.15.2',
-        # 'hmmlearn >= 0.2.0',
-        # 'scikit-learn',  # needed by hmmlearn
-        # 'pomegranate >= 0.9.0',
+        'hmmlearn >= 0.2.0',
+        'scikit-learn',  # needed by hmmlearn
+        'pomegranate >= 0.9.0',
         'matplotlib >= 1.3.1',
         'numpy >= 1.9',
         'pandas >= 0.18.1',

--- a/skgenome/tabio/bedio.py
+++ b/skgenome/tabio/bedio.py
@@ -21,7 +21,7 @@ def read_bed(infile):
     Sets of regions are separated by "track" lines. This function stops reading
     after encountering a track line other than the first one in the file.
     """
-    # ENH: just pd.read_table, skip 'track'
+    # ENH: just pd.read_csv, skip 'track'
     @report_bad_line
     def _parse_line(line):
         fields = line.split('\t', 6)

--- a/skgenome/tabio/genepred.py
+++ b/skgenome/tabio/genepred.py
@@ -143,7 +143,7 @@ def read_refflat(infile, cds=False, exons=False):
     colnames = cols_shared + cols_rest
     usecols = [c for c in colnames if not c.startswith('_')]
     # Parse the file contents
-    dframe = pd.read_table(infile,  header=None, na_filter=False,
+    dframe = pd.read_csv(infile, sep='\t',  header=None, na_filter=False,
                            names=colnames, usecols=usecols,
                            dtype={c: str for c in cols_shared},
                            converters=converters)

--- a/skgenome/tabio/gff.py
+++ b/skgenome/tabio/gff.py
@@ -51,7 +51,7 @@ def read_gff(infile, tag=r'(Name|gene_id|gene_name|gene)', keep_type=None):
                 'score', 'strand', 'phase', 'attribute']
     coltypes = ['str', 'str', 'str', 'int', 'int',
                 'str', 'str', 'str', 'str']
-    dframe = pd.read_table(infile, comment='#', header=None, na_filter=False,
+    dframe = pd.read_csv(infile, sep='\t', comment='#', header=None, na_filter=False,
                            names=colnames, dtype=dict(zip(colnames, coltypes)))
     dframe = (dframe
               .assign(start=dframe.start - 1,

--- a/skgenome/tabio/picard.py
+++ b/skgenome/tabio/picard.py
@@ -18,7 +18,8 @@ def read_interval(infile):
 
     Coordinate indexing is from 1.
     """
-    dframe = pd.read_table(infile,
+    dframe = pd.read_csv(infile,
+                           sep='\t', 
                            comment='@', # Skip the SAM header
                            names=["chromosome", "start", "end", "strand", "gene",
                                  ])
@@ -38,7 +39,7 @@ def read_picard_hs(infile):
         %gc, mean_coverage, normalized_coverage (float)
 
     """
-    dframe = pd.read_table(infile, na_filter=False, dtype={
+    dframe = pd.read_csv(infile, sep='\t', na_filter=False, dtype={
         "chrom": "str",
         "start": "int",
         "end": "int",

--- a/skgenome/tabio/seg.py
+++ b/skgenome/tabio/seg.py
@@ -137,7 +137,7 @@ def parse_seg(infile, chrom_names=None, chrom_prefix=None, from_log10=False):
             raise ValueError("SEG file contains no data")
         # Parse the SEG file contents
         try:
-            dframe = pd.read_table(handle, names=col_names, header=None,
+            dframe = pd.read_csv(handle, sep='\t', names=col_names, header=None,
                                 # * pandas.io.common.CParserError: Error
                                 #   tokenizing data. C error: Calling
                                 #   read(nbytes) on source failed. Try

--- a/skgenome/tabio/tab.py
+++ b/skgenome/tabio/tab.py
@@ -16,7 +16,7 @@ def read_tab(infile):
     The format is BED-like, but with a header row included and with
     arbitrary extra columns.
     """
-    dframe = pd.read_table(infile, dtype={'chromosome': 'str'})
+    dframe = pd.read_csv(infile, sep='\t', dtype={'chromosome': 'str'})
     if "log2" in dframe.columns:
         # Every bin needs a log2 value; the others can be NaN
         d2 = dframe.dropna(subset=["log2"])

--- a/skgenome/tabio/vcfsimple.py
+++ b/skgenome/tabio/vcfsimple.py
@@ -35,7 +35,8 @@ def read_vcf_simple(infile):
         dtypes = {c: str for c in colnames}
         dtypes['start'] = int
         del dtypes['qual']
-        table = pd.read_table(handle,
+        table = pd.read_csv(handle,
+                              sep='\t', 
                               header=None,
                               na_filter=False,
                               names=colnames,
@@ -55,7 +56,8 @@ def read_vcf_sites(infile):
                 'qual', 'filter', 'end']
     dtypes = {'chromosome': str, 'start': int, 'id': str,
               'ref': str, 'alt': str, 'filter': str}
-    table = pd.read_table(infile,
+    table = pd.read_csv(infile,
+                          sep='\t', 
                           comment='#',
                           header=None,
                           na_filter=False,


### PR DESCRIPTION
Hi ewa

Here are some of the changes I did... 

corrected travis build
replaced read_table(... ) with read_csv(..., sep='\t',...) - this will eliminate a whole bunch of warning messages as pandas read_table is being deprecated... does not change anything of the functionality

lastly on cnvlib/reference.py file I remove the male_reference argument in a couple of lines that is causing the erroneous inference of gender of the input control samples when creating a male reference.

